### PR TITLE
fix belong to error

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,3 +1,4 @@
 class Booking < ApplicationRecord
-  belongs_to :user, :flat
+  belongs_to :user
+  belongs_to :flat
 end


### PR DESCRIPTION
Fixed error message caused by belongs to twice in one line